### PR TITLE
[ADD]API 세팅

### DIFF
--- a/hooks/useGetClimate/index.ts
+++ b/hooks/useGetClimate/index.ts
@@ -1,0 +1,33 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { AxiosResult, Climate } from '@type/Api'
+import axios, { AxiosError, AxiosResponse } from 'axios'
+
+export const getClimate = async (startDate: number): Promise<AxiosResult> => {
+  const response: AxiosResponse = await axios(
+    `${process.env.NEXT_PUBLIC_BASE_URL}`,
+    {
+      params: {
+        serviceKey: process.env.NEXT_PUBLIC_API_KEY,
+        pageNo: 1,
+        numOfRows: 10,
+        dataType: 'JSON',
+        dataCd: 'ASOS',
+        dateCd: 'DAY',
+        startDt: startDate,
+        endDt: startDate + 6,
+        stnIds: 108,
+      },
+    },
+  )
+  return response.data.response.body
+}
+
+export const useGetClimate = (
+  date: number,
+  options?: Omit<
+    UseQueryOptions<AxiosResult, AxiosError<unknown, any>, Partial<Climate>[]>,
+    'initialData' | 'queryFn' | 'queryKey'
+  >,
+) => {
+  return useQuery(['climate', date], () => getClimate(date), options)
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
   swcMinify: true,
   compiler: {
     styledComponents: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^4.19.1",
         "@types/node": "18.11.11",
         "@types/react-dom": "18.0.9",
+        "axios": "^1.2.1",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
         "next": "13.0.6",
@@ -1027,12 +1028,27 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/axe-core": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
       "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
+      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1164,6 +1180,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1262,6 +1289,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dir-glob": {
@@ -1948,6 +1983,38 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2608,6 +2675,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3001,6 +3087,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -4299,10 +4390,25 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "axe-core": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
       "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA=="
+    },
+    "axios": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
+      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -4399,6 +4505,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4470,6 +4584,11 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -4981,6 +5100,21 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5436,6 +5570,19 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -5688,6 +5835,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@tanstack/react-query": "^4.19.1",
     "@types/node": "18.11.11",
     "@types/react-dom": "18.0.9",
+    "axios": "^1.2.1",
     "eslint": "8.29.0",
     "eslint-config-next": "13.0.6",
     "next": "13.0.6",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,19 @@
 import GlobalStyle from '@styles/GlobalStyle'
 import Layout from '@components/Layout'
 import type { AppProps } from 'next/app'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 export default function App({ Component, pageProps }: AppProps) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { refetchOnWindowFocus: false } },
+  })
+
   return (
-    <>
+    <QueryClientProvider client={client}>
       <GlobalStyle />
       <Layout>
         <Component {...pageProps} />
       </Layout>
-    </>
+    </QueryClientProvider>
   )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,16 @@
+import { useGetClimate } from 'hooks/useGetClimate'
+
 export default function Home() {
-  return <div>메인페이지</div>
+  const { data, isLoading } = useGetClimate(20221201, {
+    select: data =>
+      data.items.item.map(item => {
+        const { avgTa, maxTa, minTa, sumRn, tm, stnNm } = item
+        const newData = { avgTa, maxTa, minTa, sumRn, tm, stnNm }
+        return newData
+      }),
+  })
+
+  console.log(data, '///////', isLoading)
+
+  return <div>메인페이지°C</div>
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,9 @@
     "paths": {
       "@pages/*": ["pages/*"],
       "@components/*": ["components/*"],
-      "@styles/*": ["styles/*"]
+      "@styles/*": ["styles/*"],
+      "@lib/*": ["lib/*"],
+      "@type/*": ["type/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "components/index.ts"],

--- a/type/Api.ts
+++ b/type/Api.ts
@@ -1,0 +1,72 @@
+export type Climate = {
+  avgCm5Te: string
+  avgCm10Te: string
+  avgCm20Te: string
+  avgCm30Te: string
+  avgLmac: string
+  avgM05Te: string
+  avgM10Te: string
+  avgM15Te: string
+  avgM30Te: string
+  avgM50Te: string
+  avgPa: string
+  avgPs: string
+  avgPv: string
+  avgRhm: string
+  avgTa: string
+  avgTca: string
+  avgTd: string
+  avgTs: string
+  avgWs: string
+  ddMefs: string
+  ddMefsHrmt: string
+  ddMes: string
+  ddMesHrmt: string
+  hr1MaxIcsr: string
+  hr1MaxIcsrHrmt: string
+  hr1MaxRn: string
+  hr1MaxRnHrmt: string
+  hr24SumRws: string
+  iscs: string
+  maxInsWs: string
+  maxInsWsHrmt: string
+  maxInsWsWd: string
+  maxPs: string
+  maxPsHrmt: string
+  maxTa: string
+  maxTaHrmt: string
+  maxWd: string
+  maxWs: string
+  maxWsHrmt: string
+  maxWsWd: string
+  mi10MaxRn: string
+  mi10MaxRnHrmt: string
+  minPs: string
+  minPsHrmt: string
+  minRhm: string
+  minRhmHrmt: string
+  minTa: string
+  minTaHrmt: string
+  minTg: string
+  n99Rn: string
+  ssDur: string
+  stnId: string
+  stnNm: string
+  sumDpthFhsc: string
+  sumFogDur: string
+  sumGsr: string
+  sumLrgEv: string
+  sumRn: string
+  sumRnDur: string
+  sumSmlEv: string
+  sumSsHr: string
+  tm: string
+}
+
+export type AxiosResult = {
+  dataType: string
+  items: { item: Climate[] }
+  numOfRows: number
+  pageNo: number
+  totalCount: number
+}


### PR DESCRIPTION
서버에서 데이터를 받아오기위한 기본적인 세팅

Axios 및 react-query 를 활용하여 데이터를 받아오도록 하였습니다.
.env에 API 키 및 BASE_URL을 저장하여 활용하였고, react-query의 경우 customHook을 활용하여 구현하였습니다.
1주일치의 날씨 데이터를 받아오도록 하였고, 날짜를 query Key로 관리하여 query를 받아오도록 하였고,
option의 경우 customHook을 불러오는 곳 마다 다르게 적용될 수 있도록 useGetClimate 에서 option 인자를 받도록 하였습니다.
--- typescript 에서 useQuery의 type에서 queryFn,queryKey를 제외한 나머지를 option 의 타입으로 활용하기 위해 Omit<T>을 사용하였고, Axios의 결과에서 원하느 값만 골라내기 위하여 select option을 활용할때 query로 받아온 데이터와 가공된 데이터의 타입이 달라지는 상황에서 가공된 데이터는 받아온 데이터에서 파생된 타입이기 때문에 Partial<T>을 활용하여 타입을 적용하였습니다.