### PR TITLE
[FIX]getWeeksLastDate 수정

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,24 +4,24 @@ import styled from 'styled-components'
 import { getWeeksFirstDate } from 'utils/getDate'
 
 export default function Home() {
-  const [date, setDate] = useState(20221201)
-  const { data, isLoading } = useGetClimate(getWeeksFirstDate(date), {
+  const [selectDate, setSelectDate] = useState(20221211)
+  const { data, isLoading } = useGetClimate(getWeeksFirstDate(selectDate), {
     select: data =>
       data.items.item.map(item => {
         const { avgTa, maxTa, minTa, sumRn, tm, stnNm } = item
         const newData = { avgTa, maxTa, minTa, sumRn, tm, stnNm }
         return newData
       }),
-    enabled: String(date).length === 8,
+    enabled: String(selectDate).length === 8,
   })
 
   const DateHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setDate(parseInt(event.target.value))
+    setSelectDate(parseInt(event.target.value))
   }
 
   return (
     <HomeContent>
-      <DateInput type="text" onChange={DateHandler} value={date | 0} />
+      <DateInput type="text" onChange={DateHandler} value={selectDate | 0} />
       <ul>
         {data?.map(climate => (
           <li key={climate.tm}>

--- a/utils/getDate.ts
+++ b/utils/getDate.ts
@@ -16,22 +16,21 @@ const DateToNum = (date: Date): number => {
 
 export const getWeeksFirstDate = (date: number) => {
   if (String(date).length < 8) return 0
-  const SelectedDate = NumToDate(date)
-  const weeksFirstDay = new Date(
-    SelectedDate.getFullYear(),
-    SelectedDate.getMonth(),
-    SelectedDate.getDate() - SelectedDate.getDay(),
-  )
-  return DateToNum(weeksFirstDay)
+  const selectedDate = NumToDate(date)
+  selectedDate.setDate(selectedDate.getDate() - selectedDate.getDay())
+  return DateToNum(selectedDate)
 }
 
 export const getWeeksLastDate = (date: number) => {
   if (String(date).length < 8) return 0
-  const SelectedDate = NumToDate(date)
-  const weeksLastDay = new Date(
-    SelectedDate.getFullYear(),
-    SelectedDate.getMonth(),
-    SelectedDate.getDate() - SelectedDate.getDay() + 6,
+  const selectedDate = NumToDate(date)
+  const lastDate = selectedDate.setDate(
+    selectedDate.getDate() - selectedDate.getDay() + 6,
   )
-  return DateToNum(weeksLastDay)
+  if (lastDate > Date.now()) {
+    const today = new Date()
+    today.setDate(today.getDate() - 1)
+    return DateToNum(today)
+  }
+  return DateToNum(selectedDate)
 }


### PR DESCRIPTION
api의 마지막날짜 기준은 당일 전날까지만 데이터를 받아올 수 있기 때문에 getWeeksLastDate의 결과가 오늘 이후의 날짜일때 하루 전날을 반환하도록 하였습니다.

Date 객체의 method로 setDate를 활용하면 return 값은 밀리초를, 해당 Date객체는 setDate의 내용으로 날짜를 변경하게 된다(setFullYear, setMonth 모두 동일) 따라서 해당주의 첫째날(일요일) 과 마지막날(토요일)을 구할때 setDate를 활용하고, setDate의 return 값이 Date.now() 보다 클 경우에는 전날값을, 작을때는 마지막날을 그대로 리턴하도록 하였습니다.